### PR TITLE
Observe RFC 6587

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Converts RFC3881 audit messages to DICOM",
   "main": "index.js",
   "scripts": {
-    "test": "tap test.js --cov",
+    "test": "tap test.js --cov -t2",
     "start": "node index"
   },
   "bin": "./index.js",

--- a/send-req.js
+++ b/send-req.js
@@ -6,7 +6,7 @@ const net = require('net');
 const rfc3881 = fs.readFileSync('rfc3881.xml', 'utf-8');
 const audit =    `<85>1 2015-12-10T09:42:24.129Z ryan-Latitude-E6540 atna-audit.js 19381 IHE+RFC-3881 - ${rfc3881}`;
 
-let client = net.connect(6060, () => {
+let client = net.connect(6161, () => {
   client.write(`${audit.length} ${audit}`);
   client.on('end', () => {
     client.end();

--- a/send-req.js
+++ b/send-req.js
@@ -6,8 +6,8 @@ const net = require('net');
 const rfc3881 = fs.readFileSync('rfc3881.xml', 'utf-8');
 const audit =    `<85>1 2015-12-10T09:42:24.129Z ryan-Latitude-E6540 atna-audit.js 19381 IHE+RFC-3881 - ${rfc3881}`;
 
-let client = net.connect(6161, () => {
-  client.write(audit);
+let client = net.connect(6060, () => {
+  client.write(`${audit.length} ${audit}`);
   client.on('end', () => {
     client.end();
   });

--- a/test.js
+++ b/test.js
@@ -20,14 +20,14 @@ tap.test('Main integration test', function(t) {
     let server = net.createServer((socket) => {
       console.log('connected to test upstream');
       socket.on('data', (buffer) => {
-        t.equal(buffer.toString(), expected);
+        t.equal(buffer.toString(), `${expected.length} ${expected}`);
         t.end();
       });
     }).listen(6262, () => {
       console.log('Test upstream server listening...');
       // send test rfc3881 message
       let client = net.connect(6161, () => {
-        client.write(audit);
+        client.write(`${audit.length} ${audit}`);
         client.on('end', () => {
           client.end();
           mediator.stopMediator(() => {


### PR DESCRIPTION
When sending syslog message over TCP you must observe RFC 6587, the
previous code did not allow for this.

https://tools.ietf.org/html/rfc6587#page-6
